### PR TITLE
Issue3

### DIFF
--- a/Net/Ethernet.hs
+++ b/Net/Ethernet.hs
@@ -77,6 +77,8 @@ instance Parse PacketType where parse = toEnum . fromIntegral # word16
 instance Parse content => Parse (Packet content) where
   parse = Packet # parse <# parse <# parse <# parse
 
+-- Unparse instance required previous unparse function to be
+-- renamed etherUnparse.
 instance (Unparse content) => Unparse (Packet content) where
   unparse p = unparse.etherUnparse $ fmap doUnparse p
 
@@ -110,6 +112,9 @@ parse p             = let ty          = toEnum (fromIntegral (p `wordAt` 12))
 
 -- Packets should be paddded elsewhere to satisfy minimum length requirement
 -- (46 bytes of data, 64 bytes including headers and CRC)
+
+-- This use to be called unparse. unparse is now used in the
+-- Unparse instance definition.
 etherUnparse            :: Packet OutPacket -> OutPacket
 etherUnparse p           = addChunk (listArray (0,13) bytes) (content p)
   where bytes                 = [ d1, d2, d3, d4, d5, d6

--- a/Net/Ethernet.hs
+++ b/Net/Ethernet.hs
@@ -77,6 +77,9 @@ instance Parse PacketType where parse = toEnum . fromIntegral # word16
 instance Parse content => Parse (Packet content) where
   parse = Packet # parse <# parse <# parse <# parse
 
+instance (Unparse content) => Unparse (Packet content) where
+  unparse p = unparse.etherUnparse $ fmap doUnparse p
+
 {-
 parse              :: InPacket -> Packet InPacket
 parse p             = let ty          = toEnum (fromIntegral (p `wordAt` 12))
@@ -107,8 +110,8 @@ parse p             = let ty          = toEnum (fromIntegral (p `wordAt` 12))
 
 -- Packets should be paddded elsewhere to satisfy minimum length requirement
 -- (46 bytes of data, 64 bytes including headers and CRC)
-unparse            :: Packet OutPacket -> OutPacket
-unparse p           = addChunk (listArray (0,13) bytes) (content p)
+etherUnparse            :: Packet OutPacket -> OutPacket
+etherUnparse p           = addChunk (listArray (0,13) bytes) (content p)
   where bytes                 = [ d1, d2, d3, d4, d5, d6
                                 , s1, s2, s3, s4, s5, s6
                                 , ty .!. 1, ty .!. 0


### PR DESCRIPTION
Made Net.Ethernet.Packet an instance of Unparse. Parsed ethernet packets can now be unparsed using doUnparse, in line with other packet types.

The old unparse function (which had a different type signature to the unparse from typeclass Unparse) has now been renamed etherUnparse.

I tested this by sniffing my network interface, parsing the packets and then unparsing them, to check one obtains what one starts with.

Best,
Richard
